### PR TITLE
allow NeverminedProvider init with nodeUri

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nevermined-io/catalog-core",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": false,
   "scripts": {
     "watch": "./node_modules/.bin/nodemon",

--- a/lib/src/catalog.tsx
+++ b/lib/src/catalog.tsx
@@ -124,8 +124,8 @@ export const NeverminedProvider = ({ children, config, verbose }: NeverminedProv
 
   useEffect(() => {
     const loadNevermined = async (): Promise<void> => {
-      if (!config.web3Provider) {
-        Logger.log('Please include web3 proivder in your sdk config. aborting.');
+      if (!config.web3Provider && !config.nodeUri) {
+        Logger.log('Please include web3 provider in your sdk config. aborting.');
         return;
       }
       setIsLoading(true);

--- a/providers/package.json
+++ b/providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nevermined-io/catalog-providers",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": false,
   "scripts": {
     "watch": "./node_modules/.bin/nodemon",


### PR DESCRIPTION
allows  NeverminedProvider to initialize without a web3Provider. sdk will use nodeUri instead