### PR TITLE
Fix: Refresh token when user switches to a new account

### DIFF
--- a/lib/src/services/account.ts
+++ b/lib/src/services/account.ts
@@ -466,7 +466,7 @@ export const useUserProfile = (
         }
       }
     })()
-  }, [Object.keys(sdk.services?.profiles || {}).length, walletAddress, reloadTrigger])
+  }, [sdk.services?.profiles, walletAddress, reloadTrigger])
 
   return {
     inputError,

--- a/lib/src/services/account.ts
+++ b/lib/src/services/account.ts
@@ -458,10 +458,7 @@ export const useUserProfile = (
               setHasFailedLoadingUserProfile(true)
             }
           }, 1000)
-        } else if (
-          addresses?.length &&
-          !addresses.some((a) => a.toLowerCase() === walletAddress?.toLowerCase())
-        ) {
+        } else if (addresses?.length && !addresses.some((a) => a.toLowerCase() === walletAddress)) {
           setNewAddress(walletAddress)
           setIsLoadingUserProfile(false)
           setHasFailedLoadingUserProfile(true)

--- a/lib/src/services/account.ts
+++ b/lib/src/services/account.ts
@@ -443,11 +443,7 @@ export const useUserProfile = (
         setIsLoadingUserProfile(false)
         setHasLoadedUserProfile(true)
       } catch (error: any) {
-        if (addresses?.length && !addresses.some((a) => a.toLowerCase() === walletAddress)) {
-          setNewAddress(walletAddress)
-          setIsLoadingUserProfile(false)
-          setHasFailedLoadingUserProfile(true)
-        } else if (error.message.includes('"statusCode":404')) {
+        if (error.message.includes('"statusCode":404')) {
           await account.generateToken()
           setTimeout(async () => {
             try {
@@ -462,6 +458,13 @@ export const useUserProfile = (
               setHasFailedLoadingUserProfile(true)
             }
           }, 1000)
+        } else if (
+          addresses?.length &&
+          !addresses.some((a) => a.toLowerCase() === walletAddress?.toLowerCase())
+        ) {
+          setNewAddress(walletAddress)
+          setIsLoadingUserProfile(false)
+          setHasFailedLoadingUserProfile(true)
         } else {
           Logger.error(error.message)
           setErrorMessage('Error getting user profile')

--- a/lib/src/services/account.ts
+++ b/lib/src/services/account.ts
@@ -413,7 +413,7 @@ export const useUserProfile = (
   useEffect(() => {
     (async () => {
       try {
-        if (!walletAddress || !sdk?.services?.profiles) {
+        if (!walletAddress || !sdk?.services?.profiles || userProfileLoadingStatus === 'loading') {
           return
         }
 


### PR DESCRIPTION
## Description

The PR fixes an issue that happens when a user switches to a newly created account and is not able to edit it due to a failing PUT request because of a stale token.

## Is this PR related with an open issue?

Related to Issue https://github.com/nevermined-io/one/issues/134

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation
